### PR TITLE
JPAConfig 수정 및 에러 해결

### DIFF
--- a/src/main/java/com/review/StoreReview/StoreReviewApplication.java
+++ b/src/main/java/com/review/StoreReview/StoreReviewApplication.java
@@ -5,11 +5,11 @@ import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
 import org.springframework.boot.autoconfigure.jdbc.XADataSourceAutoConfiguration;
+import org.springframework.context.annotation.ComponentScan;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
-
+@ComponentScan(basePackages={"com.review.StoreReview.config"})
 @EnableJpaAuditing
-@SpringBootApplication()
-@EnableAutoConfiguration(exclude={DataSourceAutoConfiguration.class, XADataSourceAutoConfiguration.class})
+@SpringBootApplication
 public class StoreReviewApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/review/StoreReview/config/CMSJpaConfig.java
+++ b/src/main/java/com/review/StoreReview/config/CMSJpaConfig.java
@@ -2,11 +2,10 @@ package com.review.StoreReview.config;
 
 import com.zaxxer.hikari.HikariDataSource;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.boot.autoconfigure.jdbc.DataSourceProperties;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.jdbc.DataSourceBuilder;
 import org.springframework.boot.orm.jpa.EntityManagerFactoryBuilder;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.orm.jpa.JpaTransactionManager;
 import org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean;
@@ -24,20 +23,27 @@ import javax.sql.DataSource;
         transactionManagerRef = "CMSTransactionManager"
 )
 public class CMSJpaConfig {
-
+    /**
+     *  아래와 같이 Datasource 값 세팅을 Java Config로 수동 설정할 때는 spring.datasource.jdbc-url로 설정해야 HikariCP가 인식한다. (SpringBoot 2.0부터 HikariCP가 기본으로 변경됨)
+     * DB를 2개 이상 사용해야할 경우 직접 Datasource를 만들어야 함
+     * @Return DataSource
+     */
     @Bean
-    @ConfigurationProperties(prefix = "spring.cms-datasource")
-    public DataSourceProperties CMSDataSourceProperties() {     // property를 이용하여 생성
-        return new DataSourceProperties();
+    @ConfigurationProperties(prefix = "spring.datasource.datasource")
+    public DataSource CMSDataSource() {          //
+        return DataSourceBuilder.create().type(HikariDataSource.class).build();
     }
 
-    @Bean
-    public DataSource CMSDataSource(@Qualifier("CMSDataSourceProperties") DataSourceProperties dsProperties) {
-        return dsProperties.initializeDataSourceBuilder().type(HikariDataSource.class).build();
-    }
+    /**
+     * - LocalContainerEntityManageFactoryBean : 컨테이너가 관리하는 EntityManagerFactory 생성하여 관리
+     * - LocalEntityManagerFactoryBean : 테스트 용도나 단지 JPA를 이용해서 데이터베이스에 접근하고자 할 때 사용 (어플리케이션에서 직접 관리)
+     * @Param EntityManagerFactoryBuilder
+     * @Param DataSource
+     * @Return LocalContainerEntityManagerFactoryBean
+     */
 
     @Bean
-    public LocalContainerEntityManagerFactoryBean CMSEntityManagerFactory(EntityManagerFactoryBuilder builder,  // Could not autowire. No beans of 'EntityManagerFactoryBuilder' type found.
+    public LocalContainerEntityManagerFactoryBean CMSEntityManagerFactory(EntityManagerFactoryBuilder builder,
                                                                            @Qualifier("CMSDataSource") DataSource dataSource) {
         return builder
                 .dataSource(dataSource)

--- a/src/main/java/com/review/StoreReview/config/LOGJpaConfig.java
+++ b/src/main/java/com/review/StoreReview/config/LOGJpaConfig.java
@@ -2,8 +2,8 @@ package com.review.StoreReview.config;
 
 import com.zaxxer.hikari.HikariDataSource;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.boot.autoconfigure.jdbc.DataSourceProperties;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.jdbc.DataSourceBuilder;
 import org.springframework.boot.orm.jpa.EntityManagerFactoryBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
@@ -22,14 +22,9 @@ import javax.sql.DataSource;
 public class LOGJpaConfig {
 
     @Bean
-    @ConfigurationProperties(prefix = "spring.log-datasource")
-    public DataSourceProperties LOGDataSourceProperties() {     // property를 이용하여 생성
-        return new DataSourceProperties();
-    }
-
-    @Bean
-    public DataSource LOGDataSource(@Qualifier("LOGDataSourceProperties") DataSourceProperties dsProperties) {
-        return dsProperties.initializeDataSourceBuilder().type(HikariDataSource.class).build();
+    @ConfigurationProperties(prefix = "spring.datasource.log-datasource")
+    public DataSource LOGDataSource() {
+        return DataSourceBuilder.create().type(HikariDataSource.class).build();
     }
 
     @Bean

--- a/src/main/java/com/review/StoreReview/config/MNGJpaConfig.java
+++ b/src/main/java/com/review/StoreReview/config/MNGJpaConfig.java
@@ -4,6 +4,7 @@ import com.zaxxer.hikari.HikariDataSource;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceProperties;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.jdbc.DataSourceBuilder;
 import org.springframework.boot.orm.jpa.EntityManagerFactoryBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
@@ -22,14 +23,9 @@ import javax.sql.DataSource;
 public class MNGJpaConfig {
 
     @Bean
-    @ConfigurationProperties(prefix = "spring.mng-datasource")
-    public DataSourceProperties MNGDataSourceProperties() {     // property를 이용하여 생성
-        return new DataSourceProperties();
-    }
-
-    @Bean
-    public DataSource MNGDataSource(@Qualifier("MNGDataSourceProperties") DataSourceProperties dsProperties) {
-        return dsProperties.initializeDataSourceBuilder().type(HikariDataSource.class).build();
+    @ConfigurationProperties(prefix = "spring.datasource.mng-datasource")
+    public DataSource MNGDataSource() {
+        return DataSourceBuilder.create().type(HikariDataSource.class).build(); // DataSource를 build하는데 편리한 class "DataSourceBuilder"
     }
 
     @Bean

--- a/src/main/java/com/review/StoreReview/domain/MNG/MngCode.java
+++ b/src/main/java/com/review/StoreReview/domain/MNG/MngCode.java
@@ -25,7 +25,7 @@ public class MngCode {
     // 2. 테이블과 매핑될 컬럼 = "CODE_ID"/
     @Id
     @Column(name= "CODE_ID")
-    private String dodeId;
+    private String codeId;
 
     // 1. 테이블과 매핑될 컬럼 = "DESC"/
     @Column(name = "DESC", nullable = false, length=100, columnDefinition = "VARCHAR(100) Default ''")
@@ -39,7 +39,7 @@ public class MngCode {
     @Builder
     public MngCode(String code_ID, String desc, UseYN use_YN)
     {
-        this.dodeId = code_ID;
+        this.codeId = code_ID;
         this.desc = desc;
         this.useYN = use_YN;
     }


### PR DESCRIPTION
- JPAConfig (Log~, CMS~, MNG~) 수정 
- MngCode의 필드명 수정
- "Attributes should be specified via @ SpringBootApplication" 에러 해결
  - how? `@SpringBootApplication`은 `@EnableAutoConfiguration`,`@Configuration`, `@ComponentScan`을 상속한 애너테이션이므로 `@SpringBootApplication`에 exclude 파라미터를 쓰면 됨
  - But, 해당 exclude 파라미터에 작성한 `(exclude={DataSourceAutoConfiguration.class, XADataSourceAutoConfiguration.class})` 는 db 없이 우선 작업할 경우에만 제외시키면 되는 요소이므로 그냥 제거함