### PR TITLE
UserSaveDtoValidator와 MockMvc 테스트코드 추가

### DIFF
--- a/src/main/java/com/review/storereview/common/AppConfig.java
+++ b/src/main/java/com/review/storereview/common/AppConfig.java
@@ -1,6 +1,7 @@
 package com.review.storereview.common;
 
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.springframework.context.annotation.Bean;
@@ -26,6 +27,8 @@ public class AppConfig {
     @Bean
     public ObjectMapper objectMapper()
     {
-        return  new ObjectMapper().registerModule(new JavaTimeModule());
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);   // Java 객체를 JSON으로 Serialize할 때 null값은 제외
+        return  objectMapper.registerModule(new JavaTimeModule());
     }
 }

--- a/src/main/java/com/review/storereview/common/exception/ParamValidationException.java
+++ b/src/main/java/com/review/storereview/common/exception/ParamValidationException.java
@@ -22,7 +22,7 @@ public class ParamValidationException extends RuntimeException{
         exceptionResponseDto = ExceptionResponseDto.createMetaDto(errorStatusCode);
     }
 
-//    public ParamValidationException(String message, Map<String, Object> errorMap) {
+//    public ParamValidationException(Map<String, String> errorMap) {
     public ParamValidationException(String message) {
         super(message);
         exceptionResponseDto =  ExceptionResponseDto.createMetaMessageDto(errorStatusCode,message);

--- a/src/main/java/com/review/storereview/controller/cust/UserApiController.java
+++ b/src/main/java/com/review/storereview/controller/cust/UserApiController.java
@@ -37,14 +37,13 @@ public class UserApiController {
         System.out.println("UserApiController: save 호출");
         // ResponseJsonOBject 사용
         ResponseJsonObject resDto = null;
-        ExceptionResponseDto exceptionResDto;
         /// 파라미터 검증
         userSaveDtoValidator.validate(userSaveRequestDto, bindingResult);
 
         // 검증 실패 시
         if (bindingResult.hasErrors()) {
             System.out.println(userSaveDtoValidator.getErrorsMap());
-            throw new ParamValidationException("회원가입 api 호출 중 에러");
+            throw new ParamValidationException("회원가입 api 호출 중 파라미터 에러");
 //            throw new ParamValidationException(userSaveDtoValidator.getErrorMap());
         }
         else {      // 성공 로직

--- a/src/main/java/com/review/storereview/controller/cust/UserApiController.java
+++ b/src/main/java/com/review/storereview/controller/cust/UserApiController.java
@@ -55,7 +55,7 @@ public class UserApiController {
 
 
     @PutMapping(value = "/api/sign_in")
-    public ResponseEntity<ResponseJsonObject> sign_in(@RequestBody UserSigninRequestDto requstDto)
+    public ResponseEntity<ResponseJsonObject> sign_in(@RequestBody UserSigninRequestDto requestDto)
     {
         ResponseJsonObject resDto = null;
         UserResponseDto responseDto;
@@ -64,7 +64,7 @@ public class UserApiController {
 
 
         // 2. Sign_in 서비스 로직
-        User user = userService.sign_in(requstDto);
+        User user = userService.sign_in(requestDto);
 
         // 3. response 데이터 가공
         responseDto = UserResponseDto.builder()

--- a/src/main/java/com/review/storereview/controller/cust/UserApiController.java
+++ b/src/main/java/com/review/storereview/controller/cust/UserApiController.java
@@ -26,17 +26,18 @@ public class UserApiController {
     public UserApiController(BaseUserService userService) {
         this.userService = userService;
     }
+
     /**
      * 회원가입 요청 처리 api
      * @param userSaveRequestDto
      * @return ResponseEntity<ResponseJsonObject>
      */
     @PostMapping("/user/signup")
-    public ResponseEntity<ResponseJsonObject> save(@ModelAttribute @RequestBody UserSaveRequestDto userSaveRequestDto, BindingResult bindingResult) throws NoSuchAlgorithmException {
+    public ResponseEntity<ResponseJsonObject> save(@RequestBody UserSaveRequestDto userSaveRequestDto, BindingResult bindingResult) throws NoSuchAlgorithmException {
         System.out.println("UserApiController: save 호출");
         // ResponseJsonOBject 사용
         ResponseJsonObject resDto = null;
-        /// 파라미터 검증
+        // 파라미터 검증
         userSaveDtoValidator.validate(userSaveRequestDto, bindingResult);
 
         // 검증 실패 시

--- a/src/main/java/com/review/storereview/controller/cust/UserApiController.java
+++ b/src/main/java/com/review/storereview/controller/cust/UserApiController.java
@@ -7,6 +7,7 @@ import com.review.storereview.dao.cust.User;
 import com.review.storereview.dto.ResponseJsonObject;
 import com.review.storereview.dto.request.UserSigninRequestDto;
 import com.review.storereview.dto.response.UserResponseDto;
+import com.review.storereview.dto.validator.UserSaveDtoValidator;
 import com.review.storereview.service.cust.BaseUserService;
 import com.review.storereview.dto.request.UserSaveRequestDto;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -14,21 +15,17 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
-
-import javax.validation.Valid;
 import java.security.NoSuchAlgorithmException;
-import java.util.Map;
-import java.util.regex.Pattern;
 
 @RestController
 public class UserApiController {
     private final BaseUserService userService;
+    private final UserSaveDtoValidator userSaveDtoValidator = new UserSaveDtoValidator();
 
     @Autowired
     public UserApiController(BaseUserService userService) {
         this.userService = userService;
     }
-
     /**
      * 회원가입 요청 처리 api
      * @param userSaveRequestDto
@@ -41,28 +38,22 @@ public class UserApiController {
         // ResponseJsonOBject 사용
         ResponseJsonObject resDto = null;
         ExceptionResponseDto exceptionResDto;
-
         /// 파라미터 검증
-//        Map<String, Object> errorMap = userValidator.validate(userSaveRequestDto, bindingResult);
+        userSaveDtoValidator.validate(userSaveRequestDto, bindingResult);
 
         // 검증 실패 시
-//        if (bindingResult.hasErrors()) {
-//            throw new ParamValidationException("회원가입 api 호출 중 에러", errorMap);
-//        }
-//        else {      // 성공 로직
-//            User user = userService.join(userSaveRequestDto);
-//            resDto = new ResponseJsonObject(ApiStatusCode.OK);
-//            return new ResponseEntity<ResponseJsonObject>(resDto, HttpStatus.OK);
-//        }
-        User user = userService.join(userSaveRequestDto);
-        resDto = new ResponseJsonObject(ApiStatusCode.OK);
-        return new ResponseEntity<ResponseJsonObject>(resDto, HttpStatus.OK);
+        if (bindingResult.hasErrors()) {
+            System.out.println(userSaveDtoValidator.getErrorsMap());
+            throw new ParamValidationException("회원가입 api 호출 중 에러");
+//            throw new ParamValidationException(userSaveDtoValidator.getErrorMap());
+        }
+        else {      // 성공 로직
+            User user = userService.join(userSaveRequestDto);
+            resDto = new ResponseJsonObject(ApiStatusCode.OK);
+            return new ResponseEntity<ResponseJsonObject>(resDto, HttpStatus.OK);
+        }
     }
-    // id 체크
-    public boolean isId(String id) {
-        String regex = "^[a-zA-Z]{1}[a-zA-Z0-9_]{4,11}$";   // 시작은 영문으로만, '_'를 제외한 특수문자 x, 영문, 숫자, '_'으로만 이루어진 5 ~ 12자 이하
-        return Pattern.matches(regex, id);
-    }
+
 
     @PutMapping(value = "/api/sign_in")
     public ResponseEntity<ResponseJsonObject> sign_in(@RequestBody UserSigninRequestDto requstDto)

--- a/src/main/java/com/review/storereview/dao/cust/User.java
+++ b/src/main/java/com/review/storereview/dao/cust/User.java
@@ -10,7 +10,7 @@ import javax.persistence.Column;
 import javax.persistence.*;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Size;
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 
 /** Class       : User (Model)
  *  Author      : 조 준 희
@@ -50,7 +50,7 @@ public class User {
     private String nickname;
 
     @Column(name="BIRTH_DATE", nullable = false)
-    private LocalDateTime birthDate;
+    private LocalDate birthDate;
 
     @Column(name="GENDER", nullable = false)
     @Enumerated(EnumType.STRING)
@@ -62,7 +62,7 @@ public class User {
 
     @Builder
     public User(String suid, String said, String id, String password
-            , String name, String nickname, LocalDateTime birthDate
+            , String name, String nickname, LocalDate birthDate
             , Gender gender, String phone) {
         this.suid = suid;
         this.said = said;

--- a/src/main/java/com/review/storereview/dto/response/UserResponseDto.java
+++ b/src/main/java/com/review/storereview/dto/response/UserResponseDto.java
@@ -4,7 +4,7 @@ import com.review.storereview.common.enumerate.Gender;
 import lombok.Builder;
 import lombok.Getter;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 
 @Getter
 public class UserResponseDto implements BaseResponseDto {
@@ -13,12 +13,12 @@ public class UserResponseDto implements BaseResponseDto {
     private String id;
     private String name;
     private String nickname;
-    private LocalDateTime birthDate;
+    private LocalDate birthDate;
     private Gender gender;
     private String phone;
 
     @Builder
-    public UserResponseDto(String suid, String said, String id, String name, String nickname, LocalDateTime birthDate, Gender gender, String phone) {
+    public UserResponseDto(String suid, String said, String id, String name, String nickname, LocalDate birthDate, Gender gender, String phone) {
         this.suid = suid;
         this.said = said;
         this.id = id;

--- a/src/main/java/com/review/storereview/dto/validator/UserSaveDtoValidator.java
+++ b/src/main/java/com/review/storereview/dto/validator/UserSaveDtoValidator.java
@@ -40,22 +40,14 @@ public class UserSaveDtoValidator implements Validator {
             errorsMap.put("id", "아이디를 입력하셔야합니다.");
         }
 
-        // 2. id : 이미 존재하는지 체크
-        if (!ObjectUtils.isEmpty(userSaveRequestDto.getId())) {
-            bindingResult.addError(new FieldError("UserSaveRequestDto"
-                    , "id"
-                    , "이미 존재하는 아이디입니다"));
-            errorsMap.put("id", "이미 존재하는 아이디입니다");
-        }
-
         /*
-        // 3. id : 패턴 체크
+        // 2. id : 패턴 체크
         String idRegex = "^[a-zA-Z]{1}[a-zA-Z0-9_]{4,11}$";   // 시작은 영문으로만, '_'를 제외한 특수문자 x, 영문, 숫자, '_'으로만 이루어진 5 ~ 12자 이하
         if(Pattern.matches(idRegex, userSaveRequestDto.getId()))
             errors.put();
-        // 4. password : 패턴 체크
+        // 3. password : 패턴 체크
 
-        // 5. phone : 패턴 체크
+        // 4. phone : 패턴 체크
         String phoneRegex = "^\\d{2,3}-\\d{3,4}-\\d{4}$";
         if (Pattern.matches(phoneRegex, userSaveRequestDto.getPhone()))
 

--- a/src/main/java/com/review/storereview/dto/validator/UserSaveDtoValidator.java
+++ b/src/main/java/com/review/storereview/dto/validator/UserSaveDtoValidator.java
@@ -45,6 +45,7 @@ public class UserSaveDtoValidator implements Validator {
         String idRegex = "^[a-zA-Z]{1}[a-zA-Z0-9_]{4,11}$";   // 시작은 영문으로만, '_'를 제외한 특수문자 x, 영문, 숫자, '_'으로만 이루어진 5 ~ 12자 이하
         if(Pattern.matches(idRegex, userSaveRequestDto.getId()))
             errors.put();
+
         // 3. password : 패턴 체크
 
         // 4. phone : 패턴 체크

--- a/src/main/java/com/review/storereview/dto/validator/UserSaveDtoValidator.java
+++ b/src/main/java/com/review/storereview/dto/validator/UserSaveDtoValidator.java
@@ -1,0 +1,69 @@
+package com.review.storereview.dto.validator;
+
+import com.review.storereview.dto.request.UserSaveRequestDto;
+import org.springframework.util.ObjectUtils;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.Errors;
+import org.springframework.validation.FieldError;
+import org.springframework.validation.Validator;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+/** Class       : UserSaveDtoValidator (DTO)
+ *  Author      : 문 윤 지
+ *  Description : 회원가입 시 파라미터에 대한 Custom Validator
+ *  History     : [2021-01-11]
+ */
+public class UserSaveDtoValidator implements Validator {
+    // 검증 오류 결과 보관
+    Map<String, String> errorsMap = new HashMap<>();
+
+    @Override
+    public boolean supports(Class<?> clazz) {   // 해당 클래스를 지원하는 Validator인지 확인
+        return UserSaveRequestDto.class.isAssignableFrom(clazz);
+    }
+
+    @Override
+    public void validate(Object target, Errors errors) {
+        UserSaveRequestDto userSaveRequestDto = (UserSaveRequestDto) target;
+        BindingResult bindingResult = (BindingResult) errors;
+
+        // 검증 로직
+        // 1. id : null 체크
+        if (ObjectUtils.isEmpty(userSaveRequestDto.getId())) {
+            bindingResult.addError(new FieldError("UserSaveRequestDto"
+            , "id"
+            , "아이디를 입력하셔야합니다."));
+//            errorMap.put(bindingResult.getFieldError().getField(), bindingResult.getFieldError().getDefaultMessage());
+            errorsMap.put("id", "아이디를 입력하셔야합니다.");
+        }
+
+        // 2. id : 이미 존재하는지 체크
+        if (!ObjectUtils.isEmpty(userSaveRequestDto.getId())) {
+            bindingResult.addError(new FieldError("UserSaveRequestDto"
+                    , "id"
+                    , "이미 존재하는 아이디입니다"));
+            errorsMap.put("id", "이미 존재하는 아이디입니다");
+        }
+
+        /*
+        // 3. id : 패턴 체크
+        String idRegex = "^[a-zA-Z]{1}[a-zA-Z0-9_]{4,11}$";   // 시작은 영문으로만, '_'를 제외한 특수문자 x, 영문, 숫자, '_'으로만 이루어진 5 ~ 12자 이하
+        if(Pattern.matches(idRegex, userSaveRequestDto.getId()))
+            errors.put();
+        // 4. password : 패턴 체크
+
+        // 5. phone : 패턴 체크
+        String phoneRegex = "^\\d{2,3}-\\d{3,4}-\\d{4}$";
+        if (Pattern.matches(phoneRegex, userSaveRequestDto.getPhone()))
+
+        // + 추가 검증 필요시 추가..
+         */
+    }
+
+    public Map<String, String> getErrorsMap() {
+        return errorsMap;
+    }
+}

--- a/src/main/java/com/review/storereview/repository/cust/BaseUserRepository.java
+++ b/src/main/java/com/review/storereview/repository/cust/BaseUserRepository.java
@@ -1,6 +1,7 @@
 package com.review.storereview.repository.cust;
 
 import com.review.storereview.dao.cust.User;
+import com.review.storereview.dto.request.UserSaveRequestDto;
 import com.review.storereview.repository.BaseRepository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -9,6 +10,5 @@ import java.util.Optional;
 @Repository
 public interface BaseUserRepository extends BaseRepository, JpaRepository<User, String> {
     Optional<User> findByIdAndPassword(String id, String password);
-    boolean existsBySuid(String Suid);    // existsBySuid로 Suid찾았는데 null
-
+    boolean existsById(String id);
 }

--- a/src/main/java/com/review/storereview/service/cust/BaseUserService.java
+++ b/src/main/java/com/review/storereview/service/cust/BaseUserService.java
@@ -12,6 +12,8 @@ public interface BaseUserService extends BaseService {
     @Transactional  // 전체에서 실패하면 Rollback됨. 따로 로직을 짜줘야함.
     User join(UserSaveRequestDto requestDto) throws NoSuchAlgorithmException;
 
+    void validateDuplicateUser(String id);
+
     // 로그인
     User sign_in(UserSigninRequestDto requestDto);
 }

--- a/src/main/java/com/review/storereview/service/cust/BaseUserService.java
+++ b/src/main/java/com/review/storereview/service/cust/BaseUserService.java
@@ -4,7 +4,6 @@ import com.review.storereview.dao.cust.User;
 import com.review.storereview.dto.request.UserSaveRequestDto;
 import com.review.storereview.dto.request.UserSigninRequestDto;
 import com.review.storereview.service.BaseService;
-import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import java.security.NoSuchAlgorithmException;
 
@@ -12,9 +11,6 @@ public interface BaseUserService extends BaseService {
     // 회원가입
     @Transactional  // 전체에서 실패하면 Rollback됨. 따로 로직을 짜줘야함.
     User join(UserSaveRequestDto requestDto) throws NoSuchAlgorithmException;
-
-     // 중복 회원 검증
-    void validateDuplicateUser(UserSaveRequestDto requestDto);
 
     // 로그인
     User sign_in(UserSigninRequestDto requestDto);

--- a/src/main/java/com/review/storereview/service/cust/UserServiceImpl.java
+++ b/src/main/java/com/review/storereview/service/cust/UserServiceImpl.java
@@ -32,6 +32,8 @@ public class UserServiceImpl implements BaseUserService {
      */
     @Override
     public User join(UserSaveRequestDto userSaveRequestDto)  {
+        validateDuplicateUser(userSaveRequestDto.getId());          // 중복 회원 검증
+
         /* 인코딩 및 PW 재설정 -> 추후 SUID, SAID 인코딩 팔요
         String encodedPW = passwordEncoder.encode(userSaveRequestDto.getPassword());
         userSaveRequestDto.setPasswordEncoding(encodedPW);
@@ -42,7 +44,14 @@ public class UserServiceImpl implements BaseUserService {
         return result; // result값이 있으면 result 반환, 아니면 other
     }
 
-
+    // 중복 회원 검증
+    @Override
+    public void validateDuplicateUser(String id) {
+        System.out.println("validateDuplicateUser 호출됨");
+        boolean isExist = userRepository.existsById(id);
+        if (isExist)  // 중복이면 true
+            throw new PersonAlreadyExistsException();
+    }
     /**
      * 로그인 서비스
      * @return User

--- a/src/main/java/com/review/storereview/service/cust/UserServiceImpl.java
+++ b/src/main/java/com/review/storereview/service/cust/UserServiceImpl.java
@@ -9,18 +9,20 @@ import com.review.storereview.dto.request.UserSaveRequestDto;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import java.util.Optional;
+import java.security.NoSuchAlgorithmException;
 
 @Service
 public class UserServiceImpl implements BaseUserService {
 
     private final BaseUserRepository userRepository;
-//    private final BCryptPasswordEncoder passwordEncoder;     // 암호화
+    //private final BCryptPasswordEncoder passwordEncoder;     // 암호화
 
     @Autowired
-    public UserServiceImpl(BaseUserRepository userRepository) {
-        this.userRepository = userRepository;
+    public UserServiceImpl(BaseUserRepository UserRepository) {
+        this.userRepository = UserRepository;
     }
 
     /**
@@ -30,9 +32,6 @@ public class UserServiceImpl implements BaseUserService {
      */
     @Override
     public User join(UserSaveRequestDto userSaveRequestDto)  {
-        // 중복 회원 검증
-        validateDuplicateUser(userSaveRequestDto);
-
         /* 인코딩 및 PW 재설정 -> 추후 SUID, SAID 인코딩 팔요
         String encodedPW = passwordEncoder.encode(userSaveRequestDto.getPassword());
         userSaveRequestDto.setPasswordEncoding(encodedPW);
@@ -41,17 +40,6 @@ public class UserServiceImpl implements BaseUserService {
         System.out.println(result.getSuid());
 
         return result; // result값이 있으면 result 반환, 아니면 other
-    }
-
-    // 중복 회원 검증
-    @Override
-    public void validateDuplicateUser(UserSaveRequestDto userSaveRequestDto) {
-        // 1. SUID, ID 중복 검증
-        boolean isSuidDuplicated = userRepository.existsBySuid(userSaveRequestDto.getSuid());
-        boolean isIdDuplicated = userRepository.existsBySuid(userSaveRequestDto.getSuid());
-
-        if (isSuidDuplicated || isIdDuplicated)  // 중복이면 true
-            throw new PersonAlreadyExistsException();
     }
 
 

--- a/src/main/java/com/review/storereview/service/cust/UserServiceImpl.java
+++ b/src/main/java/com/review/storereview/service/cust/UserServiceImpl.java
@@ -46,11 +46,14 @@ public class UserServiceImpl implements BaseUserService {
     // 중복 회원 검증
     @Override
     public void validateDuplicateUser(UserSaveRequestDto userSaveRequestDto) {
-//        User user = userRepository.findBySuid(userSaveRequestDto.getSuid());
-        boolean isExist = userRepository.existsBySuid(userSaveRequestDto.getSuid());
-        if (isExist)  // 중복이면 true
+        // 1. SUID, ID 중복 검증
+        boolean isSuidDuplicated = userRepository.existsBySuid(userSaveRequestDto.getSuid());
+        boolean isIdDuplicated = userRepository.existsBySuid(userSaveRequestDto.getSuid());
+
+        if (isSuidDuplicated || isIdDuplicated)  // 중복이면 true
             throw new PersonAlreadyExistsException();
     }
+
 
     /**
      * 로그인 서비스

--- a/src/test/java/com/review/storereview/common/exception/handler/GlobalExceptionHandlerTest.java
+++ b/src/test/java/com/review/storereview/common/exception/handler/GlobalExceptionHandlerTest.java
@@ -3,32 +3,17 @@ package com.review.storereview.common.exception.handler;
 import com.review.storereview.common.enumerate.Gender;
 import com.review.storereview.common.exception.PersonAlreadyExistsException;
 import com.review.storereview.dto.request.UserSaveRequestDto;
+import com.review.storereview.repository.cust.BaseUserRepository;
 import com.review.storereview.service.cust.UserServiceImpl;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-import java.time.LocalDate;
-import static org.junit.jupiter.api.Assertions.*;
 
+@DisplayName("GlobalExceptionHandler 테스트")
 class GlobalExceptionHandlerTest {
-    @Autowired
-    private UserServiceImpl userService;
-
-    @Test
-    @DisplayName("이미 있는 ID로 회원가입시 실패")
-    public void 중복회원생성_예외() throws RuntimeException{
-        // given
-        LocalDate birthDate = LocalDate.now();
-        UserSaveRequestDto userDto = UserSaveRequestDto.builder().suid("EE001341155s").said("test1").id("banan99").name("뭉지").nickname("moon").password("123456").birthDate(birthDate).gender(Gender.W).phone("01013572468")
-                .build();
-        System.out.println(userDto.getSuid());
-        assertThrows(PersonAlreadyExistsException.class,
-                () -> {
-                    userService.join(userDto);
-
-                    userService.join(userDto);
-                });
-//        assertEquals("Person already exists", type);
-    }
 }

--- a/src/test/java/com/review/storereview/controller/cust/UserApiControllerTest.java
+++ b/src/test/java/com/review/storereview/controller/cust/UserApiControllerTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
@@ -26,13 +27,13 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @MockBean(JpaMetamodelMappingContext.class)
-@ExtendWith(SpringExtension.class)  // JUnit 프레임워크가 테스트를 실행할 시 내장된 Runner를 실행 -> bean 주입
+@ExtendWith(MockitoExtension.class)  // JUnit 프레임워크가 테스트를 실행할 시 내장된 Runner를 실행 -> bean 주입
 @DisplayName("UserApiController 테스트")
 @WebMvcTest(UserApiController.class)
 class UserApiControllerTest {
 
     private MockMvc mvc;
-    @MockBean private UserServiceImpl userService;
+    @MockBean private UserServiceImpl userService;  // 목 객체
 
     @BeforeEach
     public void setUp() {   // UserApiController를 MockMvc 객체로 만든다.

--- a/src/test/java/com/review/storereview/controller/cust/UserApiControllerTest.java
+++ b/src/test/java/com/review/storereview/controller/cust/UserApiControllerTest.java
@@ -1,152 +1,143 @@
 package com.review.storereview.controller.cust;
 
-import com.review.storereview.common.enumerate.ApiStatusCode;
 import com.review.storereview.common.enumerate.Gender;
+import com.review.storereview.common.exception.ParamValidationException;
 import com.review.storereview.dao.cust.User;
-import com.review.storereview.dto.ResponseJsonObject;
-import com.review.storereview.dto.request.UserSaveRequestDto;
-import com.review.storereview.dto.request.UserSigninRequestDto;
-import com.review.storereview.repository.cust.BaseUserRepository;
 import com.review.storereview.service.cust.UserServiceImpl;
-import org.aspectj.lang.annotation.Before;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 import org.springframework.http.MediaType;
-import org.springframework.test.annotation.Commit;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.MockMvcBuilder;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.filter.CharacterEncodingFilter;
-
 import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.util.Optional;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
-//@WebMvcTest(UserApiController.class)
+@MockBean(JpaMetamodelMappingContext.class)
 @ExtendWith(SpringExtension.class)  // JUnit 프레임워크가 테스트를 실행할 시 내장된 Runner를 실행 -> bean 주입
-@SpringBootTest
 @DisplayName("UserApiController 테스트")
+@WebMvcTest(UserApiController.class)
 class UserApiControllerTest {
 
-    @Autowired private BaseUserRepository userRepository;
-    private UserServiceImpl userService = new UserServiceImpl(userRepository);
+    private MockMvc mvc;
+    @MockBean private UserServiceImpl userService;
 
-//    private MockMvc mvc;
-//    @MockBean private UserServiceImpl userService;
-
-//    @BeforeEach
-//    public void setUp() {
-//        mvc = MockMvcBuilders.standaloneSetup(new UserApiController(userService))
-//                .addFilters(new CharacterEncodingFilter("UTF-8", true))
-//                .build();
-//    }
-    @Test
-    @DisplayName("로그인 테스트")
-    public void  로그인_테스트()
-    {
-        String user_id = "redjoon10@gmail.com";
-        String password = "1234567";
-        UserSigninRequestDto requstDto = new UserSigninRequestDto(user_id, password);
-
-        Optional<User> user = userRepository.findByIdAndPassword(requstDto.getUserId(),requstDto.getPassword());
-
-        if(user.isPresent()) {
-            ResponseJsonObject resDto = new ResponseJsonObject(ApiStatusCode.OK).setData(user.get());
-            Assertions.assertThat(user.get().getSuid()).isEqualTo("RE001341154s");
-        }
-    }
-
-//    @Transactional  // 테스트 실행 후 다시 Rollback 된다. (@Commit 붙여줄 경우 테스트 시 실행된 트랜잭션이 커밋되어 롤백되지않는다.)
-//    @Commit
-//    @Test
-//    @DisplayName("회원가입 테스트")
-//    public void 유저생성_조회() throws Exception {    // mvc.perform() -> throws Exception
-//        // given
-//        final LocalDateTime birthDate = LocalDateTime.of(1999, 11, 15, 0, 0);
-//        given(userService.join(any()))
-//                .willReturn(
-//                        User.builder()
-//                                .suid("RE001341155s")
-//                                .said("KA0223874453")
-//                                .id("banan99")
-//                                .name("문윤지")
-//                                .nickname("moonz")
-//                                .password("12345678")
-//                                .birthDate(birthDate)
-//                                .gender(Gender.W)
-//                                .phone("01012345678")
-//                                .build());
-//
-//        // when
-//        final ResultActions actions =
-//                mvc.perform(
-//                        post("/api/signup")
-//                                .contentType(MediaType.APPLICATION_JSON)    // 미디어타입 설정
-//                                .accept(MediaType.APPLICATION_JSON)
-//                                .characterEncoding("UTF-8")
-//                                .content(
-//                                        "{"
-//                                                + " \"suid\" : \"RE001341155s\", "
-//                                                + " \"said\" : \"KA0223874453\", "
-//                                                + " \"id\" : \"banan99\", "
-//                                                + " \"name\" : \"문윤지\", "
-//                                                + " \"nickname\" : \"moonz\", "
-//                                                + " \"password\" : \"12345678\", "
-//                                                + " \"birthDate\" : \"1999-11-15T00:00\", "
-//                                                + " \"gender\" : \"W\", "
-//                                                + " \"phone\" : \"01012345678\", "
-//                                                + "}"));
-//
-//        // then
-//        actions
-//                .andExpect(status().isCreated())
-//                .andExpect(jsonPath("suid").value("RE001341155s"))
-//                .andExpect(jsonPath("id").value("banan99"))
-//                .andExpect(jsonPath("gender").value("W"));
-//    }
-
-    @Transactional  // 테스트 실행 후 다시 Rollback 된다. (@Commit 붙여줄 경우 테스트 시 실행된 트랜잭션이 커밋되어 롤백되지않는다.)
-    @Commit
-    @Test
-    public void 유저생성_조회() {
-        // given
-        LocalDate birthDate = LocalDate.of(1999, 11, 15);
-
-        UserSaveRequestDto userSaveRequestDto = UserSaveRequestDto.builder()     // hibernate: 같은 KEY값은 UPDATE
-                .suid("RE001341155s")
-                .said("KA0223874453")
-                .id("moonz99")
-                .name("문")
-                .nickname("moonz")
-                .password("1234567")
-                .birthDate(birthDate)
-                .gender(Gender.W)
-                .phone("01012345678")
+    @BeforeEach
+    public void setUp() {   // UserApiController를 MockMvc 객체로 만든다.
+        mvc = MockMvcBuilders.standaloneSetup(new UserApiController(userService))
+                .addFilters(new CharacterEncodingFilter("UTF-8", true)) // charset을 UTF-8로 설정 (option)
                 .build();
-
-        userService.join(userSaveRequestDto);
-        // given
-        Optional<User> result = Optional.ofNullable(userRepository.findBySuid("RE001341155s"));
-        System.out.println("조회값 : " + result.get().getSuid());
-        // then
-        Assertions.assertThat(result.get().getSuid()).isEqualTo("RE001341155s");
     }
 
-}
+    /**
+     * MockHttpServletResponse:
+     *            Status = 200
+     *     Error message = null
+     *           Headers = [Content-Type:"application/json;charset=UTF-8"]
+     *      Content type = application/json;charset=UTF-8
+     *              Body = {"meta":{"code":200},"data":null}
+     *     Forwarded URL = null
+     *    Redirected URL = null
+     *           Cookies = []
+     * @throws Exception
+     */
+    @Test
+    @DisplayName("회원가입 Controller 테스트")
+    public void 회원가입_컨트롤러테스트() throws Exception {    // mvc.perform() -> throws Exception
+        // given
+        final LocalDate birthDate = LocalDate.of(1999, 11, 15);
+        given(userService.join(any()))
+                .willReturn(
+                        User.builder()
+                                .suid("DE001341155s")
+                                .said("KA0223874453")
+                                .id("banan99")
+                                .name("문윤지")
+                                .nickname("moonz")
+                                .password("12345678")
+                                .birthDate(birthDate)
+                                .gender(Gender.W)
+                                .phone("01012345678")
+                                .build());
 
+        // when
+        final ResultActions actions =
+                mvc.perform(        // perform() : MockMvcRequestBuilders를 통해서 구현한 Request를 테스트
+                        post("/user/signup")
+                                .contentType(MediaType.APPLICATION_JSON)    // 미디어타입 설정
+                                .accept(MediaType.APPLICATION_JSON)
+                                .characterEncoding("UTF-8")
+                                .content(
+                                        "{"
+                                                + " \"suid\" : \"DE001341155s\", "
+                                                + " \"said\" : \"KA0223874453\", "
+                                                + " \"id\" : \"banan99\", "
+                                                + " \"name\" : \"문윤지\", "
+                                                + " \"nickname\" : \"moonz\", "
+                                                + " \"password\" : \"12345678\", "
+                                                + " \"birthDate\" : \"1999-11-15T00:00\", "
+                                                + " \"gender\" : \"W\", "
+                                                + " \"phone\" : \"01012345678\" "
+                                                + "}"));
+        actions
+                .andDo(print())
+                .andExpect(status().isOk())      // HttpStatus.OK(200)
+                .andExpect(content().contentType("application/json;charset=utf-8"))     // contentType 검증
+                .andExpect(jsonPath("$.meta.code").value(200));     // response 검증
+    }
+
+    // 중복 회원가입 테스트
+    @Test
+    @DisplayName("중복 회원가입 Controller 테스트")
+    public void 중복회원가입_컨트롤러테스트() throws Exception {
+        // given
+        final LocalDate birthDate = LocalDate.of(1999, 11, 15);
+        given(userService.join(any()))
+                .willReturn(
+                        User.builder()
+                                .suid("RE001341155s")
+                                .said("KA0223874453")
+                                .id("banan99")
+                                .name("문윤지")
+                                .nickname("moonz")
+                                .password("12345678")
+                                .birthDate(birthDate)
+                                .gender(Gender.W)
+                                .phone("01012345678")
+                                .build());
+
+        // when
+        org.assertj.core.api.Assertions.assertThatThrownBy( () ->
+                mvc.perform(
+                                    post("/user/signup")
+                                            .contentType(MediaType.APPLICATION_JSON)
+                                            .accept(MediaType.APPLICATION_JSON)
+                                            .characterEncoding("UTF-8")
+                                            .content(
+                                                    "{"
+                                                            + " \"suid\" : \"RE001341155s\", "
+                                                            + " \"said\" : \"KA0223874453\", "
+                                                            + " \"id\" : \"banan99\", "
+                                                            + " \"name\" : \"문윤지\", "
+                                                            + " \"nickname\" : \"moonz\", "
+                                                            + " \"password\" : \"12345678\", "
+                                                            + " \"birthDate\" : \"1999-11-15T00:00\", "
+                                                            + " \"gender\" : \"W\", "
+                                                            + " \"phone\" : \"01012345678\" "
+                                                            + "}"))
+                        .andExpect(status().isOk()))
+                        .hasCause(new ParamValidationException("회원가입 api 호출 중 에러"));
+                }
+}

--- a/src/test/java/com/review/storereview/repository/cust/BaseUserRepositoryTest.java
+++ b/src/test/java/com/review/storereview/repository/cust/BaseUserRepositoryTest.java
@@ -1,0 +1,4 @@
+import static org.junit.jupiter.api.Assertions.*;
+class BaseUserRepositoryTest {
+  
+}

--- a/src/test/java/com/review/storereview/repository/cust/BaseUserRepositoryTest.java
+++ b/src/test/java/com/review/storereview/repository/cust/BaseUserRepositoryTest.java
@@ -1,4 +1,55 @@
+package com.review.storereview.repository.cust;
+
+import com.review.storereview.common.enumerate.ApiStatusCode;
+import com.review.storereview.common.enumerate.Gender;
+import com.review.storereview.dao.cust.User;
+import com.review.storereview.dto.ResponseJsonObject;
+import com.review.storereview.dto.request.UserSaveRequestDto;
+import com.review.storereview.dto.request.UserSigninRequestDto;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
 import static org.junit.jupiter.api.Assertions.*;
+@SpringBootTest
+@DisplayName("User Repository Test")
 class BaseUserRepositoryTest {
-  
+    @Autowired
+    private BaseUserRepository userRepository;
+
+    @Test
+    @DisplayName("로그인 테스트")
+    public void  로그인_테스트()
+    {
+        String user_id = "redjoon10@gmail.com";
+        String password = "1234567";
+        UserSigninRequestDto requstDto = new UserSigninRequestDto(user_id, password);
+
+        Optional<User> user = userRepository.findByIdAndPassword(requstDto.getUserId(),requstDto.getPassword());
+
+        if(user.isPresent()) {
+            ResponseJsonObject resDto = new ResponseJsonObject(ApiStatusCode.OK).setData(user.get());
+            Assertions.assertThat(user.get().getSuid()).isEqualTo("RE001341154s");
+        }
+    }
+
+    @Test
+    @DisplayName("회원가입 레파지토리 테스트")
+    public void 회원가입_테스트() {
+        LocalDate birthDate = LocalDate.of(1999, 11, 15);
+        UserSaveRequestDto userSaveRequestDto = UserSaveRequestDto.builder()     // hibernate: 같은 KEY값은 UPDATE
+                .suid("RE001341155s").said("KA0223874453").id("moonz99").name("문").nickname("moonz").password("1234567")
+                .birthDate(birthDate).gender(Gender.W).phone("01012345678")
+                .build();
+        userRepository.save(userSaveRequestDto.toEntity());
+        Optional<User> result = Optional.ofNullable(userRepository.findBySuid("RE001341155s"));
+        System.out.println("조회값 : " + result.get().getSuid());
+
+        Assertions.assertThat(result.get().getSuid()).isEqualTo("RE001341155s");
+    }
 }

--- a/src/test/java/com/review/storereview/service/cust/UserServiceImplTest.java
+++ b/src/test/java/com/review/storereview/service/cust/UserServiceImplTest.java
@@ -1,0 +1,4 @@
+import static org.junit.jupiter.api.Assertions.*;
+class UserServiceImplTest {
+  
+}

--- a/src/test/java/com/review/storereview/service/cust/UserServiceImplTest.java
+++ b/src/test/java/com/review/storereview/service/cust/UserServiceImplTest.java
@@ -1,70 +1,50 @@
 package com.review.storereview.service.cust;
 
-import com.review.storereview.common.enumerate.ApiStatusCode;
 import com.review.storereview.common.enumerate.Gender;
-import com.review.storereview.dao.cust.User;
-import com.review.storereview.dto.ResponseJsonObject;
+import com.review.storereview.common.exception.PersonAlreadyExistsException;
 import com.review.storereview.dto.request.UserSaveRequestDto;
-import com.review.storereview.dto.request.UserSigninRequestDto;
-import com.review.storereview.repository.cust.BaseUserRepository;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.annotation.Commit;
-import org.springframework.transaction.annotation.Transactional;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.LocalDate;
-import java.util.Optional;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.when;
 
-@SpringBootTest
+@ExtendWith(MockitoExtension.class)
 @DisplayName("UserServiceImpl 테스트")
 class UserServiceImplTest {
-    @Autowired
-    private BaseUserRepository userRepository;
-    private UserServiceImpl userService = new UserServiceImpl(userRepository);
+//    private UserServiceImpl userService = new UserServiceImpl(userRepository);
+    LocalDate birthDate = LocalDate.of(1999, 11, 15);
 
     @Test
-    @DisplayName("로그인 테스트")
-    public void  로그인_테스트()
-    {
-        String user_id = "redjoon10@gmail.com";
-        String password = "1234567";
-        UserSigninRequestDto requstDto = new UserSigninRequestDto(user_id, password);
+    public void 유저_생성(@Mock UserServiceImpl userService) {
+        // given
+        UserSaveRequestDto userSaveRequestDto = UserSaveRequestDto.builder()     // hibernate: 같은 KEY값은 UPDATE
+                .suid("RE001341155s").said("KA0223874453").id("moonz99").name("문").nickname("moonz").password("1234567")
+                .birthDate(birthDate).gender(Gender.W).phone("01012345678")
+                .build();
 
-        Optional<User> user = userRepository.findByIdAndPassword(requstDto.getUserId(),requstDto.getPassword());
-
-        if(user.isPresent()) {
-            ResponseJsonObject resDto = new ResponseJsonObject(ApiStatusCode.OK).setData(user.get());
-            Assertions.assertThat(user.get().getSuid()).isEqualTo("RE001341154s");
-        }
+        doThrow(new PersonAlreadyExistsException()).when(userService).validateDuplicateUser(userSaveRequestDto.getId());
     }
-
+/*
     @Transactional  // 테스트 실행 후 다시 Rollback 된다. (@Commit 붙여줄 경우 테스트 시 실행된 트랜잭션이 커밋되어 롤백되지않는다.)
     @Commit
     @Test
-    public void 유저생성_조회() {
+    @DisplayName("이미 있는 ID로 회원가입시 실패")
+    public void 중복회원생성_예외() throws RuntimeException{
         // given
-        LocalDate birthDate = LocalDate.of(1999, 11, 15);
-
-        UserSaveRequestDto userSaveRequestDto = UserSaveRequestDto.builder()     // hibernate: 같은 KEY값은 UPDATE
-                .suid("RE001341155s")
-                .said("KA0223874453")
-                .id("moonz99")
-                .name("문")
-                .nickname("moonz")
-                .password("1234567")
-                .birthDate(birthDate)
-                .gender(Gender.W)
-                .phone("01012345678")
+        LocalDate birthDate = LocalDate.now();
+        UserSaveRequestDto userSaveRequestDto = UserSaveRequestDto.builder().suid("EE001341155s").said("test1").id("banan99").name("뭉지").nickname("moon").password("123456").birthDate(birthDate).gender(Gender.W).phone("01013572468")
                 .build();
+        System.out.println(userSaveRequestDto.getSuid());
+        assertThrows(PersonAlreadyExistsException.class,
+                () -> {
+                    userService.join(userSaveRequestDto);
 
-        // when
-        userService.join(userSaveRequestDto);
-        Optional<User> result = Optional.ofNullable(userRepository.findBySuid("RE001341155s"));
-        System.out.println("조회값 : " + result.get().getSuid());
-        // then
-        Assertions.assertThat(result.get().getSuid()).isEqualTo("RE001341155s");
-    }
+                    userService.join(userSaveRequestDto);
+                });
+    }*/
 }

--- a/src/test/java/com/review/storereview/service/cust/UserServiceImplTest.java
+++ b/src/test/java/com/review/storereview/service/cust/UserServiceImplTest.java
@@ -1,4 +1,70 @@
-import static org.junit.jupiter.api.Assertions.*;
+package com.review.storereview.service.cust;
+
+import com.review.storereview.common.enumerate.ApiStatusCode;
+import com.review.storereview.common.enumerate.Gender;
+import com.review.storereview.dao.cust.User;
+import com.review.storereview.dto.ResponseJsonObject;
+import com.review.storereview.dto.request.UserSaveRequestDto;
+import com.review.storereview.dto.request.UserSigninRequestDto;
+import com.review.storereview.repository.cust.BaseUserRepository;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.Commit;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+@SpringBootTest
+@DisplayName("UserServiceImpl 테스트")
 class UserServiceImplTest {
-  
+    @Autowired
+    private BaseUserRepository userRepository;
+    private UserServiceImpl userService = new UserServiceImpl(userRepository);
+
+    @Test
+    @DisplayName("로그인 테스트")
+    public void  로그인_테스트()
+    {
+        String user_id = "redjoon10@gmail.com";
+        String password = "1234567";
+        UserSigninRequestDto requstDto = new UserSigninRequestDto(user_id, password);
+
+        Optional<User> user = userRepository.findByIdAndPassword(requstDto.getUserId(),requstDto.getPassword());
+
+        if(user.isPresent()) {
+            ResponseJsonObject resDto = new ResponseJsonObject(ApiStatusCode.OK).setData(user.get());
+            Assertions.assertThat(user.get().getSuid()).isEqualTo("RE001341154s");
+        }
+    }
+
+    @Transactional  // 테스트 실행 후 다시 Rollback 된다. (@Commit 붙여줄 경우 테스트 시 실행된 트랜잭션이 커밋되어 롤백되지않는다.)
+    @Commit
+    @Test
+    public void 유저생성_조회() {
+        // given
+        LocalDate birthDate = LocalDate.of(1999, 11, 15);
+
+        UserSaveRequestDto userSaveRequestDto = UserSaveRequestDto.builder()     // hibernate: 같은 KEY값은 UPDATE
+                .suid("RE001341155s")
+                .said("KA0223874453")
+                .id("moonz99")
+                .name("문")
+                .nickname("moonz")
+                .password("1234567")
+                .birthDate(birthDate)
+                .gender(Gender.W)
+                .phone("01012345678")
+                .build();
+
+        // when
+        userService.join(userSaveRequestDto);
+        Optional<User> result = Optional.ofNullable(userRepository.findBySuid("RE001341155s"));
+        System.out.println("조회값 : " + result.get().getSuid());
+        // then
+        Assertions.assertThat(result.get().getSuid()).isEqualTo("RE001341155s");
+    }
 }


### PR DESCRIPTION
## What is this PR? :mag:
** UserSaveDtoValidator와 MockMvc 테스트코드 추가

## Changes :memo:
- `UserApiControllerTest` 추가 : ‘/user/signup’ 에 대한 Controller 테스트 : 회원가입 (MockMvc 이용)
- `UserSaveDtoValidator` 생성 : User Validator 개발
- Validator 관련 UserApiControllerTest 테스트코드 작성 :  중복 회원가입의 경우
   => 디버깅으로 Validator 클래스를 거치는 지 확인 완료
   - 다만, 프론트분과 구체적인 회원정보에 대한 규칙?을 아직 상의하지 못해 “id가 없는 경우”, “id가 이미 있는 경우”만 검사하도록 했습니다. (차후 추가 예정)
  - 에러 응답객체로 전달하는 것까지는 진행하지 못함. (아래 "예정" 두가지 먼저 한 후 진행할 예정)
  
### 부가 수정
- UserApiControllerTest 에 있던 `유저생성_조회()` 와 `로그인_테스트()` 는 UserServiceImplTest 로 이동

### 예정 
1. 에러 반환 객체 `exceptionResponseDto`와 응답 객체 `ResponseJsonObject` 를 한 개로 통일
2. 현재 파라미터 에러 발생 시 추가되는 String message를 Map형식으로 변경하고, 하나의 필드로 추가 예정 (null일 때는 생략될 예정. 생성 후 확인해보겠습니다.)

3. 위의 과정을 거친 후 validator에서 생성하는 errorsMap까지 응답 객체에게 전달하는 코드도 작성 예정